### PR TITLE
Update no-inferrable-types and no-console rule

### DIFF
--- a/lib/config/rules/rule-helpers/console-methods.js
+++ b/lib/config/rules/rule-helpers/console-methods.js
@@ -7,7 +7,6 @@ module.exports = [
   'debug',
   'dir',
   'dirxml',
-  'error',
   'exception',
   'group',
   'groupCollapsed',

--- a/lib/config/rules/typescript.js
+++ b/lib/config/rules/typescript.js
@@ -14,7 +14,7 @@ module.exports = {
   // Forbids empty interfaces.
   'no-empty-interface': false,
   // Disallows explicit type declarations for variables or parameters initialized to a number, string, or boolean.
-  'no-inferrable-types': true,
+  'no-inferrable-types': [true, 'ignore-params'],
   // Disallows internal `module`
   'no-internal-module': false,
   // Disallows the use constant number values outside of variable assignments.


### PR DESCRIPTION
* Added `ignore-params` flag to `no-inferrable-types`.
* Removed `error` from  `no-console`. We have code that logs errors. We should be using `console.error()` instead of `console.log()`