### PR TITLE
Update variable name rule

### DIFF
--- a/lib/config/rules/style.js
+++ b/lib/config/rules/style.js
@@ -52,7 +52,7 @@ module.exports = {
   // Require or disallow a space before function parenthesis
   'space-before-function-paren': require('./rule-helpers/space-before-function-paren-rule'),
   // Checks variable names for various errors.
-  'variable-name': [true, 'ban-keywords', 'check-format', 'allow-leading-underscore'],
+  'variable-name': [true, 'ban-keywords', 'check-format', 'allow-pascal-case'],
   // Enforces whitespace style conventions.
   'whitespace': [true, 'check-branch', 'check-decl', 'check-operator', 'check-module', 'check-separator', 'check-type', 'check-typecast'],
 };


### PR DESCRIPTION
Allow pascal case as well as camel case. 

This does not strictly enforce what is allowed as pascal case or camel case. It simply allows either one of them to be allowed as a variable name. So this implicitly reject snake case. 

We can add a custom rule to enforce pascal and came case to their proper variable names, class names etc. 