### PR TITLE
Bug Fix #37

### DIFF
--- a/src/customRules/jsxBooleanValueRule.ts
+++ b/src/customRules/jsxBooleanValueRule.ts
@@ -44,6 +44,7 @@ export class Rule extends Lint.Rules.AbstractRule {
 function isInitializerTrue(initializer: ts.JsxExpression | ts.StringLiteral | null | undefined): boolean {
     return initializer &&
     initializer.kind === ts.SyntaxKind.JsxExpression &&
+    initializer.expression &&
     initializer.expression.kind === ts.SyntaxKind.TrueKeyword;
 }
 


### PR DESCRIPTION
I noticed this bug in Neutron through one of VSCode's terminal panes.
Specifically the `OUTPUT` terminal pane. 

See https://github.com/Shopify/tslint-config-shopify/issues/37
