### PR TITLE
Fix docs on import-type-order

### DIFF
--- a/docs/rules/import-type-order.md
+++ b/docs/rules/import-type-order.md
@@ -4,7 +4,12 @@
 - Improves readability and organization by grouping naturally related items together.
 
 ## Rule Details
-Improves readability and organization by grouping related imports together. Imports should be listed in order of: external modules, absolute paths, relative paths, relative siblings.
+Enforce order of import statement types. Import statments should be listed in the following order:
+
+- Externals
+- Absolute paths
+- Parent paths
+- Sibling paths
 
 The following are considered warnings
 ```js

--- a/src/customRules/importTypeOrderRule.ts
+++ b/src/customRules/importTypeOrderRule.ts
@@ -6,7 +6,7 @@ export class Rule extends Lint.Rules.AbstractRule {
   /* tslint:disable:object-literal-sort-keys */
   public static metadata: Lint.IRuleMetadata = {
     'ruleName': 'import-type-order',
-    'description': 'Enforce structure to your imports. Import structure should be listed in the following order: modules, absolute imports,  relative parent/ancestor directories, relative sibling directors.',
+    'description': 'Improves readability and organization by grouping related imports together. Imports should be listed in order of: external modules, absolute paths, relative paths, relative siblings.',
     'hasFix': false,
     'optionsDescription': 'Not configurable.',
     'options': null,


### PR DESCRIPTION
Follow up on https://github.com/Shopify/tslint-config-shopify/pull/48#discussion_r106034060

I put that description in the markdown docs instead of the rule description. *face palm* 