### PR TITLE
Add fixer for trailing-comma-interface rule

### DIFF
--- a/src/customRules/trailingCommaInterfaceRule.ts
+++ b/src/customRules/trailingCommaInterfaceRule.ts
@@ -4,17 +4,15 @@ import * as Lint from 'tslint';
 class TrailingCommaInterfaceWalker extends Lint.RuleWalker {
    private static FAILURE_STRING = 'Trailing comma is required in interfaces properties.';
    public visitInterfaceDeclaration(node: ts.InterfaceDeclaration) {
-    const potentialDelimiters = [';'];
-    node.members.map((propertySignature) => {
+    node.members.filter((propertySignature) => propertySignature.getText().slice(-1) !== ',')
+      .forEach((propertySignature) => {
         const lastChar = propertySignature.getText().slice(-1);
-        if (lastChar !== ',') {
-          const lastCharPosition = propertySignature.getStart() + propertySignature.getWidth() - 1;
-          const replacementText = (potentialDelimiters.indexOf(lastChar) === -1) ? `${lastChar},` : ',';
-          const fixer = new Lint.Replacement(lastCharPosition, 1, replacementText);
-          const failure = this.createFailure(lastCharPosition, 1, TrailingCommaInterfaceWalker.FAILURE_STRING, fixer);
-          this.addFailure(failure);
-        }
-    });
+        const lastCharPosition = propertySignature.getStart() + propertySignature.getWidth() - 1;
+        const replacementText = (lastChar === ';') ? `,` : `${lastChar},`;
+        const fixer = new Lint.Replacement(lastCharPosition, 1, replacementText);
+        const failure = this.createFailure(lastCharPosition, 1, TrailingCommaInterfaceWalker.FAILURE_STRING, fixer);
+        this.addFailure(failure);
+      });
   }
 }
 

--- a/src/customRules/trailingCommaInterfaceRule.ts
+++ b/src/customRules/trailingCommaInterfaceRule.ts
@@ -6,9 +6,10 @@ class TrailingCommaInterfaceWalker extends Lint.RuleWalker {
    public visitInterfaceDeclaration(node: ts.InterfaceDeclaration) {
     node.members.map((propertySignature) => {
         if (propertySignature.getText().slice(-1) !== ',') {
-            this.addFailure(this.createFailure(propertySignature.getStart(),
-                                               propertySignature.getWidth(),
-                                               TrailingCommaInterfaceWalker.FAILURE_STRING));
+          const delimiterPosition = propertySignature.getStart() + propertySignature.getWidth() - 1;
+          const fixer = new Lint.Replacement(delimiterPosition, 1, ',');
+          const failure = this.createFailure(delimiterPosition, 1, TrailingCommaInterfaceWalker.FAILURE_STRING, fixer);
+          this.addFailure(failure);
         }
     });
   }

--- a/src/customRules/trailingCommaInterfaceRule.ts
+++ b/src/customRules/trailingCommaInterfaceRule.ts
@@ -4,11 +4,14 @@ import * as Lint from 'tslint';
 class TrailingCommaInterfaceWalker extends Lint.RuleWalker {
    private static FAILURE_STRING = 'Trailing comma is required in interfaces properties.';
    public visitInterfaceDeclaration(node: ts.InterfaceDeclaration) {
+    const potentialDelimiters = [';'];
     node.members.map((propertySignature) => {
-        if (propertySignature.getText().slice(-1) !== ',') {
-          const delimiterPosition = propertySignature.getStart() + propertySignature.getWidth() - 1;
-          const fixer = new Lint.Replacement(delimiterPosition, 1, ',');
-          const failure = this.createFailure(delimiterPosition, 1, TrailingCommaInterfaceWalker.FAILURE_STRING, fixer);
+        const lastChar = propertySignature.getText().slice(-1);
+        if (lastChar !== ',') {
+          const lastCharPosition = propertySignature.getStart() + propertySignature.getWidth() - 1;
+          const replacementText = (potentialDelimiters.indexOf(lastChar) === -1) ? `${lastChar},` : ',';
+          const fixer = new Lint.Replacement(lastCharPosition, 1, replacementText);
+          const failure = this.createFailure(lastCharPosition, 1, TrailingCommaInterfaceWalker.FAILURE_STRING, fixer);
           this.addFailure(failure);
         }
     });

--- a/test/rules/trailing-comma-interface/test.ts.fix
+++ b/test/rules/trailing-comma-interface/test.ts.fix
@@ -1,4 +1,5 @@
 export interface Foo {
   curly?: string[],
   larry: number,
+  moe: number,
 }

--- a/test/rules/trailing-comma-interface/test.ts.fix
+++ b/test/rules/trailing-comma-interface/test.ts.fix
@@ -1,0 +1,4 @@
+export interface Foo {
+  curly?: string[],
+  larry: number,
+}

--- a/test/rules/trailing-comma-interface/test.ts.lint
+++ b/test/rules/trailing-comma-interface/test.ts.lint
@@ -1,7 +1,7 @@
 export interface Foo {
   curly?: string[];
-  ~~~~~~~~~~~~~~~~~  [Trailing comma is required in interfaces properties.]
+                  ~  [Trailing comma is required in interfaces properties.]
   larry: number;
-  ~~~~~~~~~~~~~~  [Trailing comma is required in interfaces properties.]
+               ~  [Trailing comma is required in interfaces properties.]
   moe: number,
 }

--- a/test/rules/trailing-comma-interface/test.ts.lint
+++ b/test/rules/trailing-comma-interface/test.ts.lint
@@ -1,7 +1,7 @@
 export interface Foo {
   curly?: string[];
-                  ~  [Trailing comma is required in interfaces properties.]
+                  ~ [0]
   larry: number;
-               ~  [Trailing comma is required in interfaces properties.]
-  moe: number,
+               ~ [0]
 }
+[0]: Trailing comma is required in interfaces properties.

--- a/test/rules/trailing-comma-interface/test.ts.lint
+++ b/test/rules/trailing-comma-interface/test.ts.lint
@@ -3,5 +3,7 @@ export interface Foo {
                   ~ [0]
   larry: number;
                ~ [0]
+  moe: number
+            ~ [0]
 }
 [0]: Trailing comma is required in interfaces properties.


### PR DESCRIPTION
This fixer will help with integrating prettier into our formatting/linting, if we decide to go with it. 

Related to https://github.com/Shopify/tslint-config-shopify/issues/51