### PR TITLE
Allow `import {foo}...` (no whitespace around `foo`)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## [Unreleased]
 
 ### Fixed
-- Fixed a regression where `import { foo }...` would be enforced instead of `import {foo}...`
-- Fixed a regression where a block could open without a space before it (e.g. `function(){ return 'foo'; }` would be valid while missing whitespace between `)` and `{`)
+- Fixed a regression where `import { foo }...` would be enforced instead of `import {foo}...` ([74](https://github.com/Shopify/tslint-config-shopify/pull/74))
+- Fixed a regression where a block could open without a space before it (e.g. `function(){ return 'foo'; }` would be valid while missing whitespace between `)` and `{`) ([74](https://github.com/Shopify/tslint-config-shopify/pull/74))
 
 
 ## [3.0.0] - 2017-06-28

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+- Fixed a regression where `import { foo }...` would be enforced instead of `import {foo}...`
+- Fixed a regression where a block could open without a space before it (e.g. `function(){ return 'foo'; }` would be valid while missing whitespace between `)` and `{`)
+
+
 ## [3.0.0] - 2017-06-28
 ### Removed
 - Removed the `untyped` config. Typed rules are now enabled by default as appropriate, and all modern editors safely disregard them instead of throwing errors.

--- a/src/rules/style.ts
+++ b/src/rules/style.ts
@@ -86,5 +86,17 @@ export default {
   // Checks variable names for various errors.
   'variable-name': [true, 'ban-keywords', 'check-format', 'allow-pascal-case'],
   // Enforces whitespace style conventions.
-  'whitespace': [true, 'check-branch', 'check-decl', 'check-operator', 'check-module', 'check-separator', 'check-type', 'check-typecast'],
+  'whitespace': [
+    true,
+    'check-branch',
+    'check-decl',
+    'check-operator',
+    // 'check-module', <- Omitted to allow `import {foo}...` (no whitespace around `foo`)
+    'check-separator',
+    'check-rest-spread',
+    'check-type',
+    'check-typecast',
+    'check-type-operator',
+    'check-preblock',
+  ],
 };


### PR DESCRIPTION
Fixes #73, where a regression would enforce `import { foo }...` instead of `import {foo}...`.

Unfortunately there is no way to enforce `import {foo} from 'foo';` with the current version of TSLint. Prettier can do it for us, though.

This also fixes a regression where this would be valid: `function(){ return 'foo'; }` (missing whitespace between `)` and `{`.