### PR TITLE
Update changelog for 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,11 @@
 # Changelog
 
-## [Unreleased]
+<!-- ## [Unreleased] -->
 
+## [3.0.1] - 2017-09-14
 ### Fixed
 - Fixed a regression where `import { foo }...` would be enforced instead of `import {foo}...` ([74](https://github.com/Shopify/tslint-config-shopify/pull/74))
 - Fixed a regression where a block could open without a space before it (e.g. `function(){ return 'foo'; }` would be valid while missing whitespace between `)` and `{`) ([74](https://github.com/Shopify/tslint-config-shopify/pull/74))
-
 
 ## [3.0.0] - 2017-06-28
 ### Removed
@@ -122,3 +122,6 @@
 ### Added
 
 - Initial release ([#5](https://github.com/Shopify/tslint-config-shopify/pull/5))
+
+[Unreleased]: https://github.com/Shopify/tslint-config-shopify/compare/v3.0.1...HEAD
+[3.0.1]: https://github.com/Shopify/tslint-config-shopify/compare/v3.0.0...v3.0.1


### PR DESCRIPTION
We should be ready for 3.0.1, which is kind of a breaking change but really fixes a regression so I consider it's a patch. Thoughts?