### PR TITLE
Remove prefer-function-over-method rule

### DIFF
--- a/src/rules/style.ts
+++ b/src/rules/style.ts
@@ -63,8 +63,8 @@ export default {
   'one-variable-per-declaration': true,
   // Requires that import statements be alphabetized.
   'ordered-imports': false,
-  // Warns for class methods that do not use ‘this’.
-  'prefer-function-over-method': true,
+  // Do not warn for class methods that do not use ‘this’.
+  'prefer-function-over-method': false,
   // Prefer foo(): void over foo: () => void in interfaces and types.
   'prefer-method-signature': true,
   // Prefer a switch statement to an if statement with simple === comparisons.


### PR DESCRIPTION
Follow up on https://github.com/Shopify/eslint-plugin-shopify/pull/45

We should also remove this rule for typescript.