### PR TITLE
Restore allowing leading underscore in variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 <!-- ## [Unreleased] -->
 
+## [3.0.2] - 2017-11-01
+### Fixed
+- Fixed a regression where `allow-leading-underscore` was removed, disallowing leading underscores in variable names ([#80](https://github.com/Shopify/tslint-config-shopify/pull/80))
+
 ## [3.0.1] - 2017-09-14
 ### Fixed
-- Fixed a regression where `import { foo }...` would be enforced instead of `import {foo}...` ([74](https://github.com/Shopify/tslint-config-shopify/pull/74))
-- Fixed a regression where a block could open without a space before it (e.g. `function(){ return 'foo'; }` would be valid while missing whitespace between `)` and `{`) ([74](https://github.com/Shopify/tslint-config-shopify/pull/74))
+- Fixed a regression where `import { foo }...` would be enforced instead of `import {foo}...` ([#74](https://github.com/Shopify/tslint-config-shopify/pull/74))
+- Fixed a regression where a block could open without a space before it (e.g. `function(){ return 'foo'; }` would be valid while missing whitespace between `)` and `{`) ([#74](https://github.com/Shopify/tslint-config-shopify/pull/74))
 
 ## [3.0.0] - 2017-06-28
 ### Removed
@@ -123,5 +127,6 @@
 
 - Initial release ([#5](https://github.com/Shopify/tslint-config-shopify/pull/5))
 
-[Unreleased]: https://github.com/Shopify/tslint-config-shopify/compare/v3.0.1...HEAD
+[Unreleased]: https://github.com/Shopify/tslint-config-shopify/compare/v3.0.2...HEAD
+[3.0.2]: https://github.com/Shopify/tslint-config-shopify/compare/v3.0.1...v3.0.2
 [3.0.1]: https://github.com/Shopify/tslint-config-shopify/compare/v3.0.0...v3.0.1

--- a/src/rules/style.ts
+++ b/src/rules/style.ts
@@ -84,7 +84,7 @@ export default {
   // Checks that type literal members are separated by semicolons. Enforces a trailing semicolon for multiline type literals.
   'type-literal-delimiter': false,
   // Checks variable names for various errors.
-  'variable-name': [true, 'ban-keywords', 'check-format', 'allow-pascal-case'],
+  'variable-name': [true, 'ban-keywords', 'check-format', 'allow-pascal-case', 'allow-leading-underscore'],
   // Enforces whitespace style conventions.
   'whitespace': [
     true,


### PR DESCRIPTION
Allows authors to add a leading underscore to unused arguments of a function (e.g. when the function signature is dictated by a third party API).

e.g.

```js
  private handleOnBeforeChange(_editor, _data, value) {
    this.setState({value});
  }
```