### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 # tslint-config-shopify
-
 [![Circle CI](https://circleci.com/gh/Shopify/eslint-plugin-shopify.svg?style=shield)](https://circleci.com/gh/Shopify/tslint-config-shopify)
 [![David-DM](https://david-dm.org/shopify/tslint-config-shopify.svg)](https://david-dm.org/Shopify/tslint-config-shopify)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # tslint-config-shopify
+
 [![Circle CI](https://circleci.com/gh/Shopify/eslint-plugin-shopify.svg?style=shield)](https://circleci.com/gh/Shopify/tslint-config-shopify)
 [![David-DM](https://david-dm.org/shopify/tslint-config-shopify.svg)](https://david-dm.org/Shopify/tslint-config-shopify)
+
+### ⚠️ Deprecated: use [eslint-plugin-shopfiy](https://github.com/Shopify/eslint-plugin-shopify) instead ⚠️
 
 Shopify’s TSlint rules and configs.
 


### PR DESCRIPTION
Should we also [deprecate](https://docs.npmjs.com/cli/deprecate) it in npm?